### PR TITLE
Fix Unicode error on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Development Installation
 2. From the project directory, run `ansible-galaxy install -r deployment/ansible/roles.txt -p deployment/ansible/roles`
 3. Copy deployment/ansible/hosts/hosts.vagrant.example to hosts.vagrant and edit with your disqus shortname and e-mail credentials. If e-mail credentials are left unconfigured, e-mails will not be sent out.
 4. Run `vagrant up`; CKAN will be available at on port 8025.
+5. Creating a sysadmin user:
+  ```
+  vagrant ssh
+  . /usr/lib/ckan/default/bin/activate
+  cd /usr/lib/ckan/default/src/ckan
+  paster sysadmin add <USERNAME> -c /etc/ckan/default/production.ini
+  ```

--- a/odp_importer/odp2ckan.py
+++ b/odp_importer/odp2ckan.py
@@ -36,17 +36,33 @@ def import_resources(ckan_api):
 
 def clear_resources(ckan_api):
     """Attempt to delete as much as possible from the target CKAN instance."""
+    logger.info("Deleting packages from CKAN instance")
     resources = ckan_api.action.package_list()
     for resource in resources:
         ckan_api.action.package_delete(id=resource)
 
+    logger.info("Deleting organizations from CKAN instance")
     organizations = ckan_api.action.organization_list()
     for org in organizations:
         ckan_api.action.organization_purge(id=org)
 
+    logger.info("Deleting groups from CKAN instance")
     groups = ckan_api.action.group_list()
     for group in groups:
         ckan_api.action.group_purge(id=group)
+
+    logger.info("Deleting free tags from CKAN instance")
+    tags = ckan_api.action.tag_list()
+    for tag in tags:
+        ckan_api.action.tag_delete(id=tag)
+
+    logger.info("Deleting vocabulary tags from CKAN instance")
+    vocabs = ckan_api.action.vocabulary_list()
+    for vocab in vocabs:
+        tags = ckan_api.action.tag_list(vocabulary_id=vocab['id'])
+        for t in tags:
+            ckan_api.action.tag_delete(id=t, vocabulary_id=vocab['id'])
+        ckan_api.action.vocabulary_delete(id=vocab['id'])
 
     logger.warn('Successfully cleared CKAN instance.\nHowever, you will need to '
                 'navigate to http://your-ckan-instance/ckan-admin/trash/ and manually '

--- a/odp_importer/opendataphilly.py
+++ b/odp_importer/opendataphilly.py
@@ -106,7 +106,7 @@ class ODPToCKANImporter(object):
                              ('rating', 'OpenDataPhilly Rating')]
         for field in extra_fields_list:
             if odp_resource[field[0]]:
-                extras.append(dict(key=field[1], value=str(odp_resource[field[0]])))
+                extras.append(dict(key=field[1], value=unicode(odp_resource[field[0]])))
 
         return extras
 


### PR DESCRIPTION
There was no reason that the resource extras needed to be ASCII-only, so
this allows them to accept Unicode values, which fixes a Unicode error
that was encountered with the latest data from OpenDataPhilly.

Also improves the --erase functionality of the script.
