### PR TITLE
Bump disqus version and insert odp_theme at beginning of plugins

### DIFF
--- a/deployment/ansible/roles/ckanext-disqus/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-disqus/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 ckan_virtualenv_path: "/usr/lib/ckan/default/"
-ckanext_disqus_version: "f58504da4df9ccb6311469af419c9d8831ce44ad"
+ckanext_disqus_version: "cf7af9ac5be5e6ff77e5f59541a0f699ef43e14b"
 ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-odp_theme/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-odp_theme/tasks/main.yml
@@ -28,6 +28,10 @@
     - { option: 'ckan.site_logo', value: '/img/odp-logo.svg' }
   notify: Restart Apache
 
+# Add to front of plugins list so our theme can override everything
 - name: Add self to CKAN plugin list
-  lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!odp_theme).)*)$" line="ckan.plugins\1 odp_theme" backrefs=yes
+  lineinfile: dest="{{ ckan_config_path }}"
+              regexp="^ckan.plugins \= (((?!odp_theme).)*)$"
+              line="ckan.plugins = odp_theme \1"
+              backrefs=yes
   notify: Restart Apache


### PR DESCRIPTION
The latest ckanext-disqus commit (pushed in Jan!) lets us override it when we need to, for example, so that we can disable it on unpublished datasets.

Pushing odp_theme to the front of the plugin list also allows us to accomplish this goal.