### PR TITLE
Get vagrant up working

### DIFF
--- a/deployment/ansible/roles/ckan-deadoralive/defaults/main.yml
+++ b/deployment/ansible/roles/ckan-deadoralive/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
 ckan_site_url: "http://localhost:8080/"
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckan_deadoralive_version: "29327db812c36f7e400f45a44ebe96674cc8ebf9"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckan_deadoralive_apikey: 'CHANGE_THIS'

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -3,3 +3,6 @@ db_name: ckan_default
 db_user: ckan_default
 db_password: ckan_default
 ckan_package_filename: 'python-ckan_2.2_amd64.deb'
+ckan_config_path: "/etc/ckan/default/production.ini"
+# Installed by the CKAN package, used by plugin roles
+ckan_virtualenv_path: "/usr/lib/ckan/default/"

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -30,6 +30,7 @@
       - iftop
       - iotop
       - libapache2-mod-wsgi
+      - libffi-dev
       - libpq5
       - nginx
       - postgresql

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -90,7 +90,7 @@
     notify: Restart Jetty
 
   - name: Set CKAN Solr server address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp=solr_url line=solr_url=http://127.0.0.1:8983/solr'
+    lineinfile: 'dest={{ ckan_config_path }} regexp=solr_url line=solr_url=http://127.0.0.1:8983/solr'
 
   # Postgres
   - name: Ensure CKAN database is created
@@ -106,7 +106,7 @@
     sudo_user: postgres
 
   - name: Set CKAN database server address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp=sqlalchemy.url line="sqlalchemy.url = postgresql://{{ db_user }}:{{ db_password }}@localhost/{{ db_name }}?sslmode=disable"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp=sqlalchemy.url line="sqlalchemy.url = postgresql://{{ db_user }}:{{ db_password }}@localhost/{{ db_name }}?sslmode=disable"'
 
   - name: Ensure database is initialised
     command: ckan db init
@@ -135,10 +135,10 @@
     sudo_user: postgres
 
   - name: Set DataStore database server write address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp="ckan.datastore.write_url" line="ckan.datastore.write_url = postgresql://ckan_default:{{ db_password }}@localhost/datastore_default"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.write_url" line="ckan.datastore.write_url = postgresql://ckan_default:{{ db_password }}@localhost/datastore_default"'
 
   - name: Set DataStore database server read address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp="ckan.datastore.read_url" line="ckan.datastore.read_url = postgresql://datastore_default:{{ db_password }}@localhost/datastore_default"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.read_url" line="ckan.datastore.read_url = postgresql://datastore_default:{{ db_password }}@localhost/datastore_default"'
 
   - name: Set DataStore database permissions
     command: ckan datastore set-permissions postgres
@@ -148,7 +148,7 @@
     file: path=/var/lib/ckan/default owner=www-data state=directory
 
   - name: Set FileStore directory path
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp="ckan.storage_path" line="ckan.storage_path = /var/lib/ckan/default"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.storage_path" line="ckan.storage_path = /var/lib/ckan/default"'
 
   - name: Ensure Apache can write to FileStore directory
     acl: name=/var/lib/ckan/default entity=www-data etype=user permissions=u+rwx

--- a/deployment/ansible/roles/ckanext-archiver/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-archiver/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 # For whatever reason ckanext-archiver doesn't install its dependencies from
 # setup.py (it used to but they changed it). If a newer version is used, make
 # sure to update requirements.txt in this role's files directory with the
 # requirements.txt from the new version.
 ckanext_archiver_version: "de57522441bae34984f8f15186d1cd95481e0acf"
 archiver_requirements_path: "/tmp/ckanext-archiver-requirements.txt"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_datajson_version: "azavea-develop"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckan_wsgi_path: "/etc/ckan/default/apache.wsgi"
 vagrant_ckanext_datajson_mountpoint: "/vagrant_ckanext-datajson"

--- a/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-ckanext_datajson_version: "azavea-develop"
+ckanext_datajson_version: "azavea-workaround"
 ckan_wsgi_path: "/etc/ckan/default/apache.wsgi"
 vagrant_ckanext_datajson_mountpoint: "/vagrant_ckanext-datajson"

--- a/deployment/ansible/roles/ckanext-deadoralive/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-deadoralive/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_deadoralive_version: "212cafd5934ac8186022822a5591deef9e70c2b8"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-disqus/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-disqus/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_disqus_version: "cf7af9ac5be5e6ff77e5f59541a0f699ef43e14b"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-googleanalytics/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-googleanalytics/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_googleanalytics_version: "0febe11dc512978e610fffd7895b5a040e4ab197"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-googleanalytics/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-googleanalytics/tasks/main.yml
@@ -11,4 +11,4 @@
 - name: Add Google Analytics configuration
   lineinfile: dest="{{ ckan_config_path }}" regexp="googleanalytics\.id" line="googleanalytics.id = {{ googleanalytics_id }}" insertafter="ckan\.plugins"
   notify: Restart Apache
-  when: googleanalytics_id
+  when: googleanalytics_id is defined and googleanalytics_id != ''

--- a/deployment/ansible/roles/ckanext-harvest/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-harvest/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_harvest_version: "stable"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-issues/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-issues/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_issues_version: "6e90ff95a30356c6550f988d1a6a124a3092486c"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckanext_issues_notify_admin: True
 ckanext_issues_notify_owner: True
 ckanext_issues_from_address: "ckan-test@localhost.local"

--- a/deployment/ansible/roles/ckanext-odp_theme/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-odp_theme/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 ckan_production: False
 ckanext_odp_theme_version: "develop"
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_odp_theme_local_src: "/vagrant_ckanext-odp_theme"
-ckan_config_path: "/etc/ckan/default/production.ini"
 vagrant_ckanext_odp_theme_mountpoint: "/vagrant_ckanext-odp_theme"

--- a/deployment/ansible/roles/ckanext-pages/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-pages/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_pages_version: "b48dbc34c78659e03d4a05c6735bfa96cedb454f"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-qa/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-qa/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 # If the version changes, make sure to update requirements.txt, too.
 ckanext_qa_version: 27023d2bd98689c02cb4d1618d69cf401eb45349
 qa_requirements_path: "/tmp/ckanext-qa-requirements.txt"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-spatial/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-spatial/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_spatial_version: "da2e1100ed9600b0b8b2ceffbadc4f966e71274f"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckanext_spatial_url: "https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg"
 ckanext_spatial_attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'


### PR DESCRIPTION
Makes a few fixes to the ansible tasks to get provisioning working.  It was getting an import error from the DataJson plugin that doesn't make sense to me, but I worked around it by changing the entrypoint for the plugin.  Since ultimately we'll be upgrading farther (i.e. PR #52), I didn't make a PR for the workaround, just put it in a branch and made this branch use it (https://github.com/azavea/ckanext-datajson/tree/feature/azavea-workaround).