### PR TITLE
Get vagrant up working with CKAN 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ Development Installation
 
 1. Make sure you have the development dependencies installed
 2. Clone the [ckanext-odp_theme](https://github.com/azavea/ckanext-odp_theme) and [ckanext-datajson](https://github.com/azavea/ckanext-datajson/) repositories to this directory's parent directory
-3. From the project directory, run `ansible-galaxy install -r deployment/ansible/roles.txt -p deployment/ansible/roles`
-4. Copy `deployment/ansible/group_vars/vagrant.example` to `vagrant` and edit with your disqus shortname and e-mail credentials. If e-mail credentials are left unconfigured, e-mails will not be sent out.
-5. Run `vagrant up`; once the Ansible provisioner finishes, CKAN will be available at http://localhost:8025
-6. Creating a sysadmin user:
+3. Copy `deployment/ansible/group_vars/vagrant.example` to `vagrant` and edit with your disqus shortname and e-mail credentials. If e-mail credentials are left unconfigured, e-mails will not be sent out.
+4. Run `vagrant up`; once the Ansible provisioner finishes, CKAN will be available at http://localhost:8025
+5. Creating a sysadmin user:
 ```
   vagrant ssh
   . /usr/lib/ckan/default/bin/activate
@@ -29,7 +28,7 @@ Development Installation
 Deployment
 -----------------
 
-1. Launch a server running Ubuntu 12.04. This server should be accessible from the deployment computer over SSH, and should have HTTP and HTTPS access to the internet.
+1. Launch a server running Ubuntu 14.04. This server should be accessible from the deployment computer over SSH, and should have HTTP and HTTPS access to the internet.
 2. Copy `deployment/ansible/hosts/hosts.staging.example` to `hosts.staging` and enter the address of the server that was just launched.
 3. Copy `deployment/ansible/group_vars/staging.example` to `staging` and edit any settings you wish to change (see above). Make sure that `ckan_site_url` matches the address at which you will access the site.
 4. Run `ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook --private-key=/absolute/path/to/server/key/file.pem --user=ubuntu --inventory-file=deployment/ansible/hosts/hosts.staging deployment/ansible/staging.yml -v`

--- a/deployment/ansible/group_vars/staging.example
+++ b/deployment/ansible/group_vars/staging.example
@@ -4,8 +4,6 @@ ckan_disqus_shortname: ENTER_SHORTNAME_HERE
 #ckan_disqus_public_key: ""
 #ckan_disqus_secret_key: ""
 ckan_production: True
-python_version: 2.7.3-0ubuntu2.2
-pip_version: 1.0-1build1
 ckan_site_url: http://localhost:80/
 ckan_deadoralive_apikey: CHANGE_THIS
 #ckan_smtp_mail_from:

--- a/deployment/ansible/group_vars/vagrant.example
+++ b/deployment/ansible/group_vars/vagrant.example
@@ -1,7 +1,5 @@
 ---
 ckan_disqus_shortname: ENTER_SHORTNAME_HERE
-python_version: 2.7.3-0ubuntu2.2
-pip_version: 1.0-1build1
 ckan_site_url: http://localhost:8080/
 ckan_deadoralive_apikey: CHANGE_THIS
 ckan_production: false

--- a/deployment/ansible/hosts/hosts.vagrant
+++ b/deployment/ansible/hosts/hosts.vagrant
@@ -1,2 +1,2 @@
 [vagrant]
-192.168.8.25    ansible_ssh_user=vagrant
+192.168.8.85    ansible_ssh_user=vagrant

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,4 +1,0 @@
-azavea.pip,0.1.0
-azavea.python,0.1.0
-azavea.virtualenv,0.1.0
-azavea.git,0.1.0

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -9,3 +9,6 @@
 
 - src: azavea.git
   version: 0.1.0
+
+- src: azavea.postgresql
+  version: 0.3.5

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,0 +1,11 @@
+- src: azavea.pip
+  version: 0.2.0
+
+- src: azavea.python
+  version: 0.1.0
+
+- src: azavea.virtualenv
+  version: 0.1.0
+
+- src: azavea.git
+  version: 0.1.0

--- a/deployment/ansible/roles/ckan-deadoralive/defaults/main.yml
+++ b/deployment/ansible/roles/ckan-deadoralive/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
 ckan_site_url: "http://localhost:8080/"
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckan_deadoralive_version: "29327db812c36f7e400f45a44ebe96674cc8ebf9"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckan_deadoralive_apikey: 'CHANGE_THIS'

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -2,9 +2,11 @@
 db_name: ckan_default
 db_user: ckan_default
 db_password: ckan_default
+ckan_package_dir: '/tmp'
 ckan_package_filename: 'python-ckan_2.2-trusty_amd64.deb'
+
+# The config and virtualenv are installed by the CKAN package
 ckan_config_path: "/etc/ckan/default/production.ini"
-# Installed by the CKAN package, used by plugin roles
 ckan_virtualenv_path: "/usr/lib/ckan/default/"
 
 ckan_pip_dependencies:

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -3,3 +3,6 @@ db_name: ckan_default
 db_user: ckan_default
 db_password: ckan_default
 ckan_package_filename: 'python-ckan_2.2_amd64.deb'
+ckan_config_path: "/etc/ckan/default/production.ini"
+# Installed by the CKAN package, used by plugin roles
+ckan_virtualenv_path: "/usr/lib/ckan/default/"

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -2,7 +2,7 @@
 db_name: ckan_default
 db_user: ckan_default
 db_password: ckan_default
-ckan_package_filename: 'python-ckan_2.2_amd64.deb'
+ckan_package_filename: 'python-ckan_2.2-trusty_amd64.deb'
 ckan_config_path: "/etc/ckan/default/production.ini"
 # Installed by the CKAN package, used by plugin roles
 ckan_virtualenv_path: "/usr/lib/ckan/default/"

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -6,3 +6,7 @@ ckan_package_filename: 'python-ckan_2.2-trusty_amd64.deb'
 ckan_config_path: "/etc/ckan/default/production.ini"
 # Installed by the CKAN package, used by plugin roles
 ckan_virtualenv_path: "/usr/lib/ckan/default/"
+
+ckan_pip_dependencies:
+  - { name: 'urllib3[secure]', version: '1.19.1' }
+  - { name: 'requests[security]', version: '2.10.0' }

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -19,3 +19,8 @@ ckan_simple_plugins:
     version: 'b48dbc34c78659e03d4a05c6735bfa96cedb454f'
     plugins:
       - 'pages'
+  - name: 'highlight-related-items'
+    repo: 'CityOfPhiladelphia/ckanext-highlight-related-items'
+    version: 'fefd941267d2c4f2551656b52af5b5fe601a7882'
+    plugins:
+      - 'highlight-related-items'

--- a/deployment/ansible/roles/ckan/defaults/main.yml
+++ b/deployment/ansible/roles/ckan/defaults/main.yml
@@ -12,3 +12,10 @@ ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckan_pip_dependencies:
   - { name: 'urllib3[secure]', version: '1.19.1' }
   - { name: 'requests[security]', version: '2.10.0' }
+
+ckan_simple_plugins:
+  - name: 'ckanext-pages'
+    repo: 'ckan/ckanext-pages'
+    version: 'b48dbc34c78659e03d4a05c6735bfa96cedb454f'
+    plugins:
+      - 'pages'

--- a/deployment/ansible/roles/ckan/meta/main.yml
+++ b/deployment/ansible/roles/ckan/meta/main.yml
@@ -4,3 +4,4 @@ dependencies:
   - { role: "azavea.git" }
   - { role: "azavea.python" }
   - { role: "azavea.pip" }
+  - { role: "azavea.postgresql" }

--- a/deployment/ansible/roles/ckan/meta/main.yml
+++ b/deployment/ansible/roles/ckan/meta/main.yml
@@ -1,0 +1,6 @@
+---
+dependencies:
+  - { role: "azavea.virtualenv" }
+  - { role: "azavea.git" }
+  - { role: "azavea.python" }
+  - { role: "azavea.pip" }

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -164,3 +164,15 @@
   - name: Ensure Apache can write to FileStore directory
     acl: name=/var/lib/ckan/default entity=www-data etype=user permissions=u+rwx
     notify: Restart Apache
+
+  # Simple plugins
+  - name: Install simple plugins into ckan virtualenv
+    command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
+    with_items: ckan_simple_plugins
+
+  - name: Add simple plugins to CKAN plugin list
+    lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!{{ item.1 }}).)*)$" line="ckan.plugins\1 {{item.1 }}" backrefs=yes
+    notify: Restart Apache
+    with_subelements:
+      - ckan_simple_plugins
+      - plugins

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -1,8 +1,5 @@
 # Adapted from https://gist.github.com/jeffbr13/08751e42c9355cc44f5d
 ---
-  - name: Update apt cache
-    apt: update_cache=yes
-
   - name: Upgrade all safe packages
     apt: upgrade=safe
 

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -30,6 +30,8 @@
       - iftop
       - iotop
       - libapache2-mod-wsgi
+      - libffi-dev
+      - libssl-dev
       - libpq5
       - nginx
       - postgresql
@@ -38,6 +40,7 @@
       - python-psycopg2
       - python-pycurl
       - python-software-properties
+      - python-dev
       - screen
       - solr-jetty
       - sudo
@@ -65,6 +68,10 @@
     with_items:
         - /var/lib/ckan/default/storage
         - /var/lib/ckan/default/storage/uploads
+
+  - name: Install pip packages not covered by dependencies
+    pip: name={{ item.name }} version={{ item.version }} virtualenv={{ ckan_virtualenv_path }}
+    with_items: ckan_pip_dependencies
 
   # Jetty & Solr
   - name: Set Jetty to start on boot

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -69,6 +69,11 @@
         - /var/lib/ckan/default/storage
         - /var/lib/ckan/default/storage/uploads
 
+  - name: Create pip.conf in virtualenv to suppress version warning
+    template: src=pip.conf.j2
+              dest={{ ckan_virtualenv_path }}/pip.conf
+              mode="0755"
+
   - name: Install pip packages not covered by dependencies
     pip: name={{ item.name }} version={{ item.version }} virtualenv={{ ckan_virtualenv_path }}
     with_items: ckan_pip_dependencies

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -89,7 +89,7 @@
     notify: Restart Jetty
 
   - name: Set CKAN Solr server address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp=solr_url line=solr_url=http://127.0.0.1:8983/solr'
+    lineinfile: 'dest={{ ckan_config_path }} regexp=solr_url line=solr_url=http://127.0.0.1:8983/solr'
 
   # Postgres
   - name: Ensure CKAN database is created
@@ -105,7 +105,7 @@
     sudo_user: postgres
 
   - name: Set CKAN database server address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp=sqlalchemy.url line="sqlalchemy.url = postgresql://{{ db_user }}:{{ db_password }}@localhost/{{ db_name }}?sslmode=disable"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp=sqlalchemy.url line="sqlalchemy.url = postgresql://{{ db_user }}:{{ db_password }}@localhost/{{ db_name }}?sslmode=disable"'
 
   - name: Ensure database is initialised
     command: ckan db init
@@ -134,10 +134,10 @@
     sudo_user: postgres
 
   - name: Set DataStore database server write address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp="ckan.datastore.write_url" line="ckan.datastore.write_url = postgresql://ckan_default:{{ db_password }}@localhost/datastore_default"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.write_url" line="ckan.datastore.write_url = postgresql://ckan_default:{{ db_password }}@localhost/datastore_default"'
 
   - name: Set DataStore database server read address
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp="ckan.datastore.read_url" line="ckan.datastore.read_url = postgresql://datastore_default:{{ db_password }}@localhost/datastore_default"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.read_url" line="ckan.datastore.read_url = postgresql://datastore_default:{{ db_password }}@localhost/datastore_default"'
 
   - name: Set DataStore database permissions
     command: ckan datastore set-permissions postgres
@@ -147,7 +147,7 @@
     file: path=/var/lib/ckan/default owner=www-data state=directory
 
   - name: Set FileStore directory path
-    lineinfile: 'dest=/etc/ckan/default/production.ini regexp="ckan.storage_path" line="ckan.storage_path = /var/lib/ckan/default"'
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.storage_path" line="ckan.storage_path = /var/lib/ckan/default"'
 
   - name: Ensure Apache can write to FileStore directory
     acl: name=/var/lib/ckan/default entity=www-data etype=user permissions=u+rwx

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -170,11 +170,11 @@
     pip:
       name: "git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
       virtualenv: "{{ ckan_virtualenv_path }}"
-    with_items: ckan_simple_plugins
+    with_items: "{{ ckan_simple_plugins }}"
 
   - name: Add simple plugins to CKAN plugin list
     lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!{{ item.1 }}).)*)$" line="ckan.plugins\1 {{item.1 }}" backrefs=yes
     notify: Restart Apache
     with_subelements:
-      - ckan_simple_plugins
+      - "{{ ckan_simple_plugins }}"
       - plugins

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -167,7 +167,9 @@
 
   # Simple plugins
   - name: Install simple plugins into ckan virtualenv
-    command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
+    pip:
+      name: "git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
+      virtualenv: "{{ ckan_virtualenv_path }}"
     with_items: ckan_simple_plugins
 
   - name: Add simple plugins to CKAN plugin list

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -52,10 +52,10 @@
 #      lineinfile: 'dest=/etc/sudoers regexp="sudo ALL=NOPASSWD: ALL" line="%sudo ALL=NOPASSWD: ALL" state=present'
 
   - name: Download CKAN package
-    get_url: 'url="http://packaging.ckan.org/{{ ckan_package_filename }}" dest=/tmp/{{ ckan_package_filename }}'
+    get_url: 'url="http://packaging.ckan.org/{{ ckan_package_filename }}" dest={{ ckan_package_dir }}/{{ ckan_package_filename }}'
 
   - name:  Install CKAN package
-    command: 'dpkg --skip-same-version -i /tmp/{{ ckan_package_filename }}'
+    command: 'dpkg --skip-same-version -i {{ ckan_package_dir }}/{{ ckan_package_filename }}'
     # http://stackoverflow.com/questions/19127493/in-ansible-how-do-you-prevent-a-dpkg-installation-task-to-notify-a-changed-stat
     register: ckan_installed
     changed_when: "'already installed' not in ckan_installed.stderr"

--- a/deployment/ansible/roles/ckan/tasks/main.yml
+++ b/deployment/ansible/roles/ckan/tasks/main.yml
@@ -77,7 +77,7 @@
     lineinfile: 'dest=/etc/default/jetty regexp=^JETTY_PORT line="JETTY_PORT=8983"'
 
   - name: Set Jetty to use system java
-    lineinfile: 'dest=/etc/default/jetty regexp=JAVA_HOME line="JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64/"'
+    lineinfile: 'dest=/etc/default/jetty regexp=JAVA_HOME line="JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/"'
     notify: Start Jetty
 
   - name: Remove CKAN schema file

--- a/deployment/ansible/roles/ckan/templates/pip.conf.j2
+++ b/deployment/ansible/roles/ckan/templates/pip.conf.j2
@@ -1,0 +1,2 @@
+[global]
+disable_pip_version_check = 1

--- a/deployment/ansible/roles/ckanext-archiver/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-archiver/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 # For whatever reason ckanext-archiver doesn't install its dependencies from
 # setup.py (it used to but they changed it). If a newer version is used, make
 # sure to update requirements.txt in this role's files directory with the
 # requirements.txt from the new version.
 ckanext_archiver_version: "de57522441bae34984f8f15186d1cd95481e0acf"
 archiver_requirements_path: "/tmp/ckanext-archiver-requirements.txt"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_datajson_version: "azavea-develop"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckan_wsgi_path: "/etc/ckan/default/apache.wsgi"
 vagrant_ckanext_datajson_mountpoint: "/vagrant_ckanext-datajson"

--- a/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-ckanext_datajson_version: "azavea-develop"
+ckanext_datajson_version: "azavea-workaround"
 ckan_wsgi_path: "/etc/ckan/default/apache.wsgi"
 vagrant_ckanext_datajson_mountpoint: "/vagrant_ckanext-datajson"

--- a/deployment/ansible/roles/ckanext-deadoralive/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-deadoralive/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_deadoralive_version: "212cafd5934ac8186022822a5591deef9e70c2b8"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-disqus/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-disqus/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_disqus_version: "cf7af9ac5be5e6ff77e5f59541a0f699ef43e14b"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-googleanalytics/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-googleanalytics/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_googleanalytics_version: "0febe11dc512978e610fffd7895b5a040e4ab197"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-googleanalytics/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-googleanalytics/tasks/main.yml
@@ -11,4 +11,4 @@
 - name: Add Google Analytics configuration
   lineinfile: dest="{{ ckan_config_path }}" regexp="googleanalytics\.id" line="googleanalytics.id = {{ googleanalytics_id }}" insertafter="ckan\.plugins"
   notify: Restart Apache
-  when: googleanalytics_id
+  when: googleanalytics_id is defined and googleanalytics_id != ''

--- a/deployment/ansible/roles/ckanext-harvest/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-harvest/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_harvest_version: "stable"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-issues/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-issues/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_issues_version: "6e90ff95a30356c6550f988d1a6a124a3092486c"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckanext_issues_notify_admin: True
 ckanext_issues_notify_owner: True
 ckanext_issues_from_address: "ckan-test@localhost.local"

--- a/deployment/ansible/roles/ckanext-odp_theme/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-odp_theme/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 ckan_production: False
 ckanext_odp_theme_version: "develop"
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_odp_theme_local_src: "/vagrant_ckanext-odp_theme"
-ckan_config_path: "/etc/ckan/default/production.ini"
 vagrant_ckanext_odp_theme_mountpoint: "/vagrant_ckanext-odp_theme"

--- a/deployment/ansible/roles/ckanext-pages/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-pages/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_pages_version: "b48dbc34c78659e03d4a05c6735bfa96cedb454f"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-pages/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-pages/defaults/main.yml
@@ -1,2 +1,0 @@
----
-ckanext_pages_version: "b48dbc34c78659e03d4a05c6735bfa96cedb454f"

--- a/deployment/ansible/roles/ckanext-pages/meta/main.yml
+++ b/deployment/ansible/roles/ckanext-pages/meta/main.yml
@@ -1,6 +1,0 @@
----
-dependencies:
-  - { role: "ckan" }
-  - { role: "azavea.virtualenv" }
-  - { role: "azavea.git"}
-  - { role: "azavea.pip"}

--- a/deployment/ansible/roles/ckanext-pages/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-pages/tasks/main.yml
@@ -1,8 +1,0 @@
----
-# Using the ansible pip module here results in breakage
-- name: Install ckanext-pages into ckan virtualenv
-  command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/ckan/ckanext-pages.git@{{ ckanext_pages_version }}#egg=ckanext-pages"
-
-- name: Add self to CKAN plugin list
-  lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!pages).)*)$" line="ckan.plugins\1 pages" backrefs=yes
-  notify: Restart Apache

--- a/deployment/ansible/roles/ckanext-qa/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-qa/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 # If the version changes, make sure to update requirements.txt, too.
 ckanext_qa_version: 27023d2bd98689c02cb4d1618d69cf401eb45349
 qa_requirements_path: "/tmp/ckanext-qa-requirements.txt"
-ckan_config_path: "/etc/ckan/default/production.ini"

--- a/deployment/ansible/roles/ckanext-qa/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-qa/tasks/main.yml
@@ -5,9 +5,10 @@
 - name: Install Python requirements
   pip: requirements="{{ qa_requirements_path }}" virtualenv="{{ ckan_virtualenv_path }}"
 
-# Using the ansible pip module here results in breakage
 - name: Install ckanext-qa into ckan virtualenv
-  command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/ckan/ckanext-qa.git@{{ ckanext_qa_version }}#egg=ckanext_qa"
+  pip:
+    name: "git+https://github.com/ckan/ckanext-qa.git@{{ ckanext_qa_version }}#egg=ckanext_qa"
+    virtualenv: "{{ ckan_virtualenv_path }}"
 
 - name: Add self to CKAN plugin list
   lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!qa).)*)$" line="ckan.plugins\1 qa" backrefs=yes

--- a/deployment/ansible/roles/ckanext-spatial/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-spatial/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-ckan_virtualenv_path: "/usr/lib/ckan/default/"
 ckanext_spatial_version: "da2e1100ed9600b0b8b2ceffbadc4f966e71274f"
-ckan_config_path: "/etc/ckan/default/production.ini"
 ckanext_spatial_url: "https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg"
 ckanext_spatial_attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.'

--- a/deployment/ansible/site.yml
+++ b/deployment/ansible/site.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: vagrant
+
   sudo: True
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "ckan" }
     - { role: "ckanext-archiver" }

--- a/deployment/ansible/site.yml
+++ b/deployment/ansible/site.yml
@@ -12,7 +12,6 @@
     - { role: "ckanext-datajson" }
     - { role: "ckan-deadoralive" }
     - { role: "ckanext-odp_theme" }
-    - { role: "ckanext-pages" }
     - { role: "ckanext-googleanalytics" }
     - { role: "odp-importer" }
     - { role: "ckan-odp-configuration" }

--- a/deployment/ansible/staging.yml
+++ b/deployment/ansible/staging.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: staging
+
   sudo: True
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "ckan" }
     - { role: "ckanext-archiver" }


### PR DESCRIPTION
This is a more involved version of PR #53.  Whereas that tried to take the shortest path to getting the existing setup working, this makes more improvements (new Vagrantfile that handles the ansible-galaxy stuff, upgrading to Trusty, some simplification of the Ansible roles) with the goal of getting the best 2.2 installation possible.

The following steps are working for me to get a running copy.  Make sure to update your `group_vars/vagrant` from the example first.  Also get a database dump (there's a recent one on the fileshare) to import from, and extract it into a directory that's accessible from inside the VM.
```
git checkout feature/unified-linear-upgrade-attempt
vagrant provision

# log in etc
vagrant ssh
sudo -s
. /usr/lib/ckan/default/bin/activate
cd /usr/lib/ckan/default/src/ckan
alias restart_the_things="echo '***Restart apache2...' && service apache2 restart && \
    echo 'Rebuild search index...' && ckan search-index rebuild -r && \
    echo 'Restart jetty...' && service jetty restart && \
    echo 'Restart nginx...' && service nginx restart"

# import database
service apache2 stop
paster db clean --config=/etc/ckan/default/production.ini
PGPASSWORD=ckan_default psql -U ckan_default -h 127.0.0.1 -d ckan_default -f <DB_DUMP_FROM_PRODUCTION>
restart_the_things
```

This also includes the `highlight-related-items` plugin (issue #51).