### PR TITLE
Disable deadoralive

### DIFF
--- a/deployment/ansible/site.yml
+++ b/deployment/ansible/site.yml
@@ -14,9 +14,7 @@
     - { role: "ckanext-disqus" }
     - { role: "ckanext-issues" }
     - { role: "ckanext-spatial" }
-    - { role: "ckanext-deadoralive" }
     - { role: "ckanext-datajson" }
-    - { role: "ckan-deadoralive" }
     - { role: "ckanext-odp_theme" }
     - { role: "ckanext-googleanalytics" }
     - { role: "odp-importer" }

--- a/deployment/ansible/staging.yml
+++ b/deployment/ansible/staging.yml
@@ -13,9 +13,7 @@
     - { role: "ckanext-disqus" }
     - { role: "ckanext-issues" }
     - { role: "ckanext-spatial" }
-    - { role: "ckanext-deadoralive" }
     - { role: "ckanext-datajson" }
-    - { role: "ckan-deadoralive" }
     - { role: "ckanext-odp_theme" }
     - { role: "ckanext-googleanalytics" }
     - { role: "ckan-odp-configuration" }


### PR DESCRIPTION
This does not actually disable `deadoralive`, but prevents it from being enabled on deploy. `deadoralive` has been disabled manually on the production instance.

Ansible tasks have been left so they can be re-enabled later.