### PR TITLE
Remove datajson fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ nosetests.xml
 # ignore logs
 *.log
 
+# Ansible cruft
+*.retry
+
 # Ansible roles
 deployment/ansible/roles/azavea.*
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Development Installation
 ---------------
 
 1. Make sure you have the development dependencies installed
-2. Clone the [ckanext-odp_theme](https://github.com/azavea/ckanext-odp_theme) and [ckanext-datajson](https://github.com/azavea/ckanext-datajson/) repositories to this directory's parent directory
+2. Clone the [ckanext-odp_theme](https://github.com/azavea/ckanext-odp_theme) repository to this directory's parent directory
 3. Copy `deployment/ansible/group_vars/vagrant.example` to `vagrant` and edit with your disqus shortname and e-mail credentials. If e-mail credentials are left unconfigured, e-mails will not be sent out.
 4. Run `vagrant up`; once the Ansible provisioner finishes, CKAN will be available at http://localhost:8025
 5. Creating a sysadmin user:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,6 @@ Vagrant.configure(2) do |config|
   config.vm.network "private_network", ip: "192.168.8.85"
 
   config.vm.synced_folder "../ckanext-odp_theme", "/vagrant_ckanext-odp_theme", nfs: true
-  config.vm.synced_folder "../ckanext-datajson", "/vagrant_ckanext-datajson", nfs: true
 
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "deployment/ansible/site.yml"

--- a/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-ckanext_datajson_version: "feature/azavea-workaround"
+# This was the latest commit on the datagov branch as of 2018-08-08
+ckanext_datajson_version: "3205ba3f9af9c3"
 ckan_wsgi_path: "/etc/ckan/default/apache.wsgi"
-vagrant_ckanext_datajson_mountpoint: "/vagrant_ckanext-datajson"

--- a/deployment/ansible/roles/ckanext-datajson/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/tasks/main.yml
@@ -3,20 +3,16 @@
 - name: Install datajson dependencies
   command: "{{ ckan_virtualenv_path }}/bin/pip install jsonschema pyyaml lepl"
 
+- name: Remove ckanext-datajson symlink from ckan virtualenv
+  file: dest={{ ckan_virtualenv_path }}/src/ckanext-datajson
+        state=absent
+  when: not ckan_production
+
+- name: Uninstall ckanext-datajson from ckan virtualenv if it is already there
+  command: "{{ ckan_virtualenv_path }}/bin/pip uninstall ckanext-datajson"
+
 - name: Install ckanext-datajson into ckan virtualenv
-  command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/azavea/ckanext-datajson.git@{{ ckanext_datajson_version }}#egg=ckanext-datajson"
-  when: ckan_production
-
-- name: Symlink ckanext-datajson into ckan virtualenv
-  file: src={{ vagrant_ckanext_datajson_mountpoint }} dest={{ ckan_virtualenv_path }}/src/ckanext-datajson
-        state=link
-  when: not ckan_production
-
-- name: Run setup.py develop
-  command: "{{ ckan_virtualenv_path }}/bin/python setup.py develop
-            chdir={{ ckan_virtualenv_path }}/src/ckanext-datajson"
-  when: not ckan_production
-
+  command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/GSA/ckanext-datajson.git@{{ ckanext_datajson_version }}#egg=ckanext-datajson"
 
 - name: Add workaround to apache.wsgi
   lineinfile: dest={{ ckan_wsgi_path }}

--- a/deployment/ansible/roles/ckanext-datajson/tasks/main.yml
+++ b/deployment/ansible/roles/ckanext-datajson/tasks/main.yml
@@ -1,18 +1,13 @@
 ---
 # Using the ansible pip module here results in breakage
-- name: Install datajson dependencies
-  command: "{{ ckan_virtualenv_path }}/bin/pip install jsonschema pyyaml lepl"
-
-- name: Remove ckanext-datajson symlink from ckan virtualenv
-  file: dest={{ ckan_virtualenv_path }}/src/ckanext-datajson
-        state=absent
-  when: not ckan_production
-
 - name: Uninstall ckanext-datajson from ckan virtualenv if it is already there
   command: "{{ ckan_virtualenv_path }}/bin/pip uninstall ckanext-datajson"
 
 - name: Install ckanext-datajson into ckan virtualenv
   command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/GSA/ckanext-datajson.git@{{ ckanext_datajson_version }}#egg=ckanext-datajson"
+
+- name: Install datajson dependencies
+  command: "{{ ckan_virtualenv_path }}/bin/pip install -r {{ ckan_virtualenv_path}}/src/ckanext-datajson/requirements.txt"
 
 - name: Add workaround to apache.wsgi
   lineinfile: dest={{ ckan_wsgi_path }}


### PR DESCRIPTION
## Overview

Switch from our fork of datajson to upstream version.

The old version had some issues - most notably it included 22 _private_ datasets and did not include 184 public datasets. The new version returns a dataset list that fully matches the `/datasets` UI.

Of the things in our fork that we added:
 - Relaxed validation no longer seems to be an issue
 - Looking in more fields for contact email is not in the upstream. Not including this modification will mean that 7 datasets that were in `data.json` with our fork will no longer provide a contact email, and 111 of the datasets not previously included will not provide a contact email (it is unclear how many of these 111 datasets _have_ an email to provide).

### Notes

 - @KlaasH and I did a lot of digging to try and understand the reasons for why we were looking at these extra email fields, but were unable to reach any concrete conclusions.


## Testing Instructions

 * `vagrant provision`
 * http://localhost:8025/data.json

Closes azavea/urban-apps#143