### PR TITLE
Upgrade CKAN to 2.8, without extensions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,9 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include any setup required, such as bundling scripts, restarting services, etc.
  * Include test case and expected output
 
+## Checklist
+
+- [ ] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?
 
 Resolves #XXX
 

--- a/UPGRADING_2.2_TO_2.8.md
+++ b/UPGRADING_2.2_TO_2.8.md
@@ -1,0 +1,59 @@
+## Upgrading from CKAN 2.2 to CKAN 2.8
+
+Some steps needed to migrate from the CKAN 2.2 installation to the CKAN 2.8 one can't be
+encapsulated in the provisioning roles.  This document is a guide to what they are and how to
+do them.
+
+### Running paster commands
+
+CKAN uses `paster` to run various maintenance commands. `paster` commands need the CKAN code and config to run properly. There are a few ways to get that:
+
+#### The `ckan` command
+The CKAN installation package puts a script at `/usr/bin/ckan` that calls `paster` with the
+necessary arguments.  It can only be run as root.
+
+#### As the `vagrant` user
+If you want to run a `paster` command as a non-privileged user, you need to activate the CKAN
+virtualenv and run the command from the CKAN source directory:
+```bash
+source /usr/lib/ckan/default/bin/activate
+cd /usr/lib/ckan/default/src/ckan
+```
+You'll also need to point it at the config file by including `-c /etc/ckan/default/production.ini`
+in the command options.
+
+### Remove tables for removed extensions
+
+Per [PR #73](https://github.com/azavea/opendataphilly-ckan/pull/73), the tables for the
+`deadoralive` and `issues` plugins should be removed.
+
+```sql
+BEGIN;
+
+-- Table for 'deadoralive'
+DROP TABLE link_checker_results;
+
+-- Tables for 'issues'
+DROP TABLE issue_category;
+DROP TABLE issue_comment;
+DROP TABLE issue;
+
+COMMIT;
+```
+
+### Migrate the database
+
+- Shut down Apache to avoid contention
+  ```
+  service apache2 stop
+  ```
+- Migrate the database
+  ```
+  ckan db upgrade -c /etc/ckan/default/production.ini
+  ```
+- Restart services
+  ```
+  service apache2 restart
+  service jetty restart
+  ckan search-index rebuild -r
+  ```

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -11,7 +11,7 @@
     - { role: "ckan.app" }
     # - { role: "ckanext-disqus" }
     # - { role: "ckanext-spatial" }
-    # - { role: "ckanext-datajson" }
+    - { role: "ckanext-datajson" }
     # - { role: "ckanext-odp_theme" }
     # - { role: "ckanext-googleanalytics" }
     - { role: "ckan-odp-configuration" }

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -9,9 +9,9 @@
 
   roles:
     - { role: "ckan.app" }
-    - { role: "ckanext-disqus" }
-    - { role: "ckanext-spatial" }
-    - { role: "ckanext-datajson" }
-    - { role: "ckanext-odp_theme" }
-    - { role: "ckanext-googleanalytics" }
+    # - { role: "ckanext-disqus" }
+    # - { role: "ckanext-spatial" }
+    # - { role: "ckanext-datajson" }
+    # - { role: "ckanext-odp_theme" }
+    # - { role: "ckanext-googleanalytics" }
     - { role: "ckan-odp-configuration" }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,4 +1,4 @@
 pip_version: '10.0.1'
 ckan_package_dir: '/tmp'
-ckan_version: '2.2'
-ckan_patch_version: '2.2.4'
+ckan_version: '2.8'
+ckan_patch_version: '2.8.1'

--- a/deployment/ansible/group_vars/vagrant.example
+++ b/deployment/ansible/group_vars/vagrant.example
@@ -1,6 +1,6 @@
 ---
 ckan_disqus_shortname: ENTER_SHORTNAME_HERE
-ckan_site_url: http://localhost:8080/
+ckan_site_url: http://localhost:8025/
 ckan_production: false
 ckan_repo_url: https://github.com/ckan/ckan
 db_name: ckan_default

--- a/deployment/ansible/roles/ckan-odp-configuration/tasks/main.yml
+++ b/deployment/ansible/roles/ckan-odp-configuration/tasks/main.yml
@@ -62,7 +62,6 @@
       - datapusher
       - resource_proxy
       - recline_preview
-      - pdf_preview
       - text_preview
     notify: Restart Apache
 
@@ -75,6 +74,25 @@
       - csv
       - xls
 
+  # DataStore config
+  - name: Set DataStore database server write address
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.write_url" line="ckan.datastore.write_url = postgresql://{{ db_user }}:{{ db_password }}@{{ db_host }}/{{ datastore_db }}"'
+
+  - name: Set DataStore database server read address
+    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.read_url" line="ckan.datastore.read_url = postgresql://{{ datastore_user }}:{{ db_password }}@{{ db_host }}/{{ datastore_db }}"'
+
+  # Database initialization
+  - name: Set CKAN database server address
+    lineinfile: 'dest={{ ckan_config_path }} regexp=sqlalchemy.url line="sqlalchemy.url = postgresql://{{ db_user }}:{{ db_password }}@{{ db_host }}/{{ db_name }}?sslmode=disable"'
+
+  - name: Ensure database is initialised
+    command: ckan db init
+    notify:
+      - Restart Apache
+      - Restart Nginx
+    when: not ckan_production
+
+  # Email and backups
   - name: Add email sending crontab
     cron: job="echo '{}' | /usr/lib/ckan/default/bin/paster --plugin=ckan post -c {{ ckan_config_path }} /api/action/send_email_notifications > /dev/null"
           name="Send Email Notifications"

--- a/deployment/ansible/roles/ckan.app/tasks/main.yml
+++ b/deployment/ansible/roles/ckan.app/tasks/main.yml
@@ -121,15 +121,15 @@
     notify: Restart Apache
 
   # Simple plugins
-  - name: Install simple plugins into ckan virtualenv
-    pip:
-      name: "git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
-      virtualenv: "{{ ckan_virtualenv_path }}"
-    with_items: "{{ ckan_simple_plugins }}"
+  # - name: Install simple plugins into ckan virtualenv
+  #   pip:
+  #     name: "git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
+  #     virtualenv: "{{ ckan_virtualenv_path }}"
+  #   with_items: "{{ ckan_simple_plugins }}"
 
-  - name: Add simple plugins to CKAN plugin list
-    lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!{{ item.1 }}).)*)$" line="ckan.plugins\1 {{item.1 }}" backrefs=yes
-    notify: Restart Apache
-    with_subelements:
-      - "{{ ckan_simple_plugins }}"
-      - plugins
+  # - name: Add simple plugins to CKAN plugin list
+  #   lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!{{ item.1 }}).)*)$" line="ckan.plugins\1 {{item.1 }}" backrefs=yes
+  #   notify: Restart Apache
+  #   with_subelements:
+  #     - "{{ ckan_simple_plugins }}"
+  #     - plugins

--- a/deployment/ansible/roles/ckan.app/tasks/main.yml
+++ b/deployment/ansible/roles/ckan.app/tasks/main.yml
@@ -37,6 +37,7 @@
       - python-pycurl
       - python-software-properties
       - python-dev
+      - redis-server
       - screen
       - solr-jetty
       - sudo
@@ -100,30 +101,13 @@
   - name: Set CKAN Solr server address
     lineinfile: 'dest={{ ckan_config_path }} regexp=solr_url line=solr_url=http://127.0.0.1:8983/solr'
 
-  # Postgres
-  - name: Set CKAN database server address
-    lineinfile: 'dest={{ ckan_config_path }} regexp=sqlalchemy.url line="sqlalchemy.url = postgresql://{{ db_user }}:{{ db_password }}@{{ db_host }}/{{ db_name }}?sslmode=disable"'
-
-  - name: Ensure database is initialised
-    command: ckan db init
-    notify:
-      - Restart Apache
-      - Restart Nginx
-    when: not ckan_production
-
+  # Repoze.who
   - name: Remove Repoze.who configuration file for CKAN
     file: path=/usr/lib/ckan/default/src/ckan/who.ini state=absent
     when: ckan_installed.changed
 
   - name: Link Repoze.who configuration file for CKAN
     file: 'path=/usr/lib/ckan/default/src/ckan/who.ini src=/etc/ckan/default/who.ini state=link'
-
-# DataStore
-  - name: Set DataStore database server write address
-    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.write_url" line="ckan.datastore.write_url = postgresql://{{ db_user }}:{{ db_password }}@{{ db_host }}/{{ datastore_db }}"'
-
-  - name: Set DataStore database server read address
-    lineinfile: 'dest={{ ckan_config_path }} regexp="ckan.datastore.read_url" line="ckan.datastore.read_url = postgresql://{{ datastore_user }}:{{ db_password }}@{{ db_host }}/{{ datastore_db }}"'
 
   # FileStore
   - name: Ensure FileStore directory exists


### PR DESCRIPTION
## Overview

Upgrades CKAN to 2.8 (from 2.2), with all extensions disabled.  Disabling all the extensions (including `odp_theme`, which applies all of our design and layout changes) leaves it in a somewhat-broken state, but it's in line with the [recommended upgrade process](http://docs.ckan.org/en/2.8/maintaining/upgrading/upgrade-package-to-minor-release.html) and restoring them one by one will allow us to handle upgrading them and dealing with any issues in a more clear and orderly way.

This also adds a document for tracking upgrade steps that can't be encapsulated in the Ansible roles and will need to be done manually.

### Demo

These don't look great, but they do show up!

Front page:
![image](https://user-images.githubusercontent.com/6598836/44410808-2e176380-a533-11e8-920b-18bc22b5a558.png)

Datasets:
![image](https://user-images.githubusercontent.com/6598836/44410818-32dc1780-a533-11e8-9ebd-cde5747ccd25.png)

### Notes

- This moves the primary database initialization and datastore database config from the `ckan.app` role to the `ckan-odp-configuration` role.  This makes more sense to me and also resolves a problem whereby the datastore initialization failed because it depended on some config that's defined in `ckan-odp-configuration`.
- As I had hoped, including the built-in plugins didn't create any issues, so this doesn't disable all plugins, just the ones provided by extensions.

## Testing Instructions

These are the steps to bring this PR up from scratch and confirm that it works for upgrading an existing database that's working with the 2.2 version.  If you have a working post-PR #74 database VM already, you can just use that and skip to "Provision the 'app' machine".  As noted below, you might want to take a snapshot of your DB machine to make it easier to iterate on issues or experiments.

#### Provision the 'database' machine on `develop`
```
git checkout develop
vagrant destroy -f database
vagrant up database
```

- Download DB dump from the fileshare, then untar in the project root directory:
```
tar -xvf ODP_db_dumps-2017-07-12.tar.gz
```

- Import the database
```
vagrant ssh database<<EOF
export PGPASSWORD=ckan_default
cd /vagrant
psql -U ckan_default -h 127.0.0.1 -d ckan_default -f ODP_db_dumps-2017-07-12/ckan_default_sanitized.sql
psql -U ckan_default -h 127.0.0.1 -d datastore_default -f ODP_db_dumps-2017-07-12/datastore_default.sql
EOF
```

- Take a snapshot in Virtualbox of the DB VM at this point, since it now approximates the current
state of the production and you might want to restore to this point

#### Provision the 'app' machine on this branch
```
git checkout feature/kjh/upgrade-ckan-to-2.8
vagrant up --provision app
```

- Migrate the database
```
vagrant ssh app -c 'sudo ckan db upgrade'
```

- Restart the services
```
vagrant ssh app <<EOF
sudo service apache2 restart
sudo service jetty restart
sudo ckan search-index rebuild -r
EOF
```

Your instance at http://localhost:8025/ should now be working, though without `odp_theme` or any of the other extensions, some elements will be broken.


Resolves https://github.com/azavea/urban-apps/issues/153
Resolves https://github.com/azavea/urban-apps/issues/154

