### PR TITLE
Restore 'odp_theme' now that it's been updated

### DIFF
--- a/UPGRADING_2.2_TO_2.8.md
+++ b/UPGRADING_2.2_TO_2.8.md
@@ -24,6 +24,7 @@ in the command options.
 
 ### Remove tables for removed extensions
 
+#### `deadoralive` and `issues`
 Per [PR #73](https://github.com/azavea/opendataphilly-ckan/pull/73), the tables for the
 `deadoralive` and `issues` plugins should be removed.
 
@@ -38,6 +39,16 @@ DROP TABLE issue_category;
 DROP TABLE issue_comment;
 DROP TABLE issue;
 
+COMMIT;
+```
+
+#### Tables for the `unpublished_feedback` feature in `odb_theme`
+
+These were created by `ckanext-odp_theme` but not used, and now the feature has been removed.
+```sql
+BEGIN;
+DROP TABLE IF EXISTS ckanext_unpublished_feedback;
+DROP TABLE IF EXISTS ckanext_unpublished_comments;
 COMMIT;
 ```
 

--- a/deployment/ansible/app.yml
+++ b/deployment/ansible/app.yml
@@ -11,6 +11,6 @@
     - { role: "ckan.app" }
     # - { role: "ckanext-spatial" }
     - { role: "ckanext-datajson" }
-    # - { role: "ckanext-odp_theme" }
+    - { role: "ckanext-odp_theme" }
     # - { role: "ckanext-googleanalytics" }
     - { role: "ckan-odp-configuration" }


### PR DESCRIPTION
## Overview

Now that https://github.com/azavea/ckanext-odp_theme/pull/57 is merged, restores the provisioning role to install the `odp_theme` extension.
Also adds some instructions for removing the tables it formerly created.

### Demo

![image](https://user-images.githubusercontent.com/6598836/45437033-2191b100-b682-11e8-93d8-ebe645f97663.png)

## Testing Instructions

Provision the `app` instance.  It should come up without incident and look almost but not exactly like the existing production site (less so if you don't have a copy of the images on your instance).

## Checklist

- [x] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?

Resolves https://github.com/azavea/urban-apps/issues/158

