### PR TITLE
Migrate 'related' plugin to 'showcase' extension

### DIFF
--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -18,7 +18,7 @@ ckan_simple_plugins:
     plugins:
       - 'pages'
   - name: 'ckanext-showcase'
-    repo: 'ckan/ckanext-showcase'
-    version: '87a7a6e1d3566edae615613f705b3b83bef75281'
+    repo: 'azavea/ckanext-showcase'
+    version: 'ba15d2dc586faf788ffead76b1595ff82cdda7a9'
     plugins:
       - 'showcase'

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -17,8 +17,3 @@ ckan_simple_plugins:
     version: '8b0d555027f1d4ab47291da57a806e617343a6c0'
     plugins:
       - 'pages'
-  # - name: 'highlight-related-items'
-  #   repo: 'CityOfPhiladelphia/ckanext-highlight-related-items'
-  #   version: 'fefd941267d2c4f2551656b52af5b5fe601a7882'
-  #   plugins:
-  #     - 'highlight-related-items'

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -17,3 +17,8 @@ ckan_simple_plugins:
     version: '8b0d555027f1d4ab47291da57a806e617343a6c0'
     plugins:
       - 'pages'
+  - name: 'ckanext-showcase'
+    repo: 'ckan/ckanext-showcase'
+    version: '87a7a6e1d3566edae615613f705b3b83bef75281'
+    plugins:
+      - 'showcase'


### PR DESCRIPTION
## Overview

~Restores the `pages` extension and~ (Update: `pages` is now a [separate PR](https://github.com/azavea/opendataphilly-ckan/pull/82) and for the moment this is pointed at the branch for that one)

Migrates from the old built-in `related` plugin to the replacement for that, `ckanext-showcase`.

Elements needed to get this all working:
- [x] Changes to `odp_theme` to make the default Showcase pieces show up: done, on https://github.com/azavea/ckanext-odp_theme/tree/feature/migrate-related-to-showcase
- ~[ ] Restore the "Featured" checkbox on the add/edit form for Showcases.~
- ~[ ] Restore the "Featured Projects" section on the home page (which was a list of related items with the "featured" checkbox checked)~
- [x] Recreate the functionality of `highlight-related-items`, i.e. make the related item tiles show up below the "Description" on the main tab of the dataset view
- [x] Make sure creation, editing, and saving works

### Demo

![image](https://user-images.githubusercontent.com/6598836/45512281-5af31b00-b76d-11e8-9e42-1f39986b210e.png)

### Notes

- The migration dance is pretty fiddly.  For example, `ckan db init`, which runs as part of development provisioning, applies migrations, so I removed that section from the `one-off` branch.  It'll still run in normal development provisioning, so don't provision the up-to-date app instance until you've done the related->showcase migration.  Also, it turns out you can't actually remove the `related` tables until after you've applied the later migrations.
- The "related" objects were basically links with a bit of metadata.  "Showcase" objects are more complex, and are represented as packages, in the same table with the datasets.  One implication is that the action of clicking on a "Related" tile was to go to the (usually external) link it represented.  With "Showcase", clicking on a tile takes you to a detail view for that showcase, which has a "Launch website" button.  Not sure if we want to try to change that or not.

## Testing Instructions

- In your `ckanext-odp_theme` directory, check out the [`feature/migrate-related-to-showcase`](https://github.com/azavea/ckanext-odp_theme/tree/feature/migrate-related-to-showcase branch).
- You'll want to start from an un-migrated database (either re-import or restore a VM snapshot).
- Follow the instructions in [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md).  They should get you a working instance, though until the template changes are made there won't be that much to show for it.
- So far, you should be able to see Showcase objects under the "Showcase" tab on the dataset detail view.

## Checklist

- [x] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?

Connects https://github.com/azavea/urban-apps/issues/155
