### PR TITLE
Restore 'pages' extension

### DIFF
--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -17,8 +17,8 @@ ckan_simple_plugins:
     version: '8b0d555027f1d4ab47291da57a806e617343a6c0'
     plugins:
       - 'pages'
-  - name: 'highlight-related-items'
-    repo: 'CityOfPhiladelphia/ckanext-highlight-related-items'
-    version: 'fefd941267d2c4f2551656b52af5b5fe601a7882'
-    plugins:
-      - 'highlight-related-items'
+  # - name: 'highlight-related-items'
+  #   repo: 'CityOfPhiladelphia/ckanext-highlight-related-items'
+  #   version: 'fefd941267d2c4f2551656b52af5b5fe601a7882'
+  #   plugins:
+  #     - 'highlight-related-items'

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -14,7 +14,7 @@ ckan_pip_dependencies:
 ckan_simple_plugins:
   - name: 'ckanext-pages'
     repo: 'ckan/ckanext-pages'
-    version: 'b48dbc34c78659e03d4a05c6735bfa96cedb454f'
+    version: '8b0d555027f1d4ab47291da57a806e617343a6c0'
     plugins:
       - 'pages'
   - name: 'highlight-related-items'

--- a/deployment/ansible/roles/ckan.app/tasks/main.yml
+++ b/deployment/ansible/roles/ckan.app/tasks/main.yml
@@ -121,15 +121,13 @@
     notify: Restart Apache
 
   # Simple plugins
-  # - name: Install simple plugins into ckan virtualenv
-  #   pip:
-  #     name: "git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
-  #     virtualenv: "{{ ckan_virtualenv_path }}"
-  #   with_items: "{{ ckan_simple_plugins }}"
+  - name: Install simple plugins into ckan virtualenv
+    command: "{{ ckan_virtualenv_path }}/bin/pip install -e git+https://github.com/{{ item.repo }}.git@{{ item.version }}#egg={{ item.name }}"
+    with_items: "{{ ckan_simple_plugins }}"
 
-  # - name: Add simple plugins to CKAN plugin list
-  #   lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!{{ item.1 }}).)*)$" line="ckan.plugins\1 {{item.1 }}" backrefs=yes
-  #   notify: Restart Apache
-  #   with_subelements:
-  #     - "{{ ckan_simple_plugins }}"
-  #     - plugins
+  - name: Add simple plugins to CKAN plugin list
+    lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.plugins(((?!{{ item.1 }}).)*)$" line="ckan.plugins\1 {{item.1 }}" backrefs=yes
+    notify: Restart Apache
+    with_subelements:
+      - "{{ ckan_simple_plugins }}"
+      - plugins


### PR DESCRIPTION
## Overview

Restores the "simple extension" provisioning step and the "pages" extension, which we use for the FAQ, Resources, Contact, and Terms pages linked in the footer.

### Demo

![image](https://user-images.githubusercontent.com/6598836/45494330-c70a5a80-b73e-11e8-95bc-c58813e32f0d.png)

## Testing Instructions

Provision the `app` VM (if you don't have a database VM, you'll have to provision and import that, too. Hopefully you have one.)  The FAQ, Resources, Contact, and Terms links in the footer should work.

## Checklist

~- [ ] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?~

Resolves #156.

