### PR TITLE
Install PDF previewer plugin

### DIFF
--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -17,6 +17,13 @@ ckan_simple_plugins:
     version: '8b0d555027f1d4ab47291da57a806e617343a6c0'
     plugins:
       - 'pages'
+  - name: 'ckanext-pdfview'
+    repo: 'ckan/ckanext-pdfview'
+    version: '99c48f31d72c554a9b5d83f41192337fb8328215'
+    plugins:
+      - 'pdf_view'
+    default_views:
+      - 'pdf_view'
   # - name: 'highlight-related-items'
   #   repo: 'CityOfPhiladelphia/ckanext-highlight-related-items'
   #   version: 'fefd941267d2c4f2551656b52af5b5fe601a7882'

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -17,6 +17,7 @@ ckan_simple_plugins:
     version: '8b0d555027f1d4ab47291da57a806e617343a6c0'
     plugins:
       - 'pages'
+    default_views: []
   - name: 'ckanext-pdfview'
     repo: 'ckan/ckanext-pdfview'
     version: '99c48f31d72c554a9b5d83f41192337fb8328215'

--- a/deployment/ansible/roles/ckan.app/tasks/main.yml
+++ b/deployment/ansible/roles/ckan.app/tasks/main.yml
@@ -131,3 +131,10 @@
     with_subelements:
       - "{{ ckan_simple_plugins }}"
       - plugins
+
+  - name: Add simple viewer plugins to default viewer CKAN list
+    lineinfile: dest="{{ ckan_config_path }}" regexp="^ckan.views.default_views(((?!{{ item.1 }}).)*)$" line="ckan.views.default_views\1 {{ item.1 }}" backrefs=yes
+    notify: Restart Apache
+    with_subelements:
+      - "{{ ckan_simple_plugins }}"
+      - default_views


### PR DESCRIPTION
## Overview

Uncomment simple plugin task and use it to install PDF previewer.
Add step to simple plugin task to add plugin to default views, for previewer plugins.

Closes azavea/urban-apps#150.


### Demo

![image](https://user-images.githubusercontent.com/960264/45508969-41010a80-b764-11e8-995f-139f5cfbfcd6.png)

![image](https://user-images.githubusercontent.com/960264/45508945-30509480-b764-11e8-8e34-a49992657987.png)


### Notes

Will rebase after #82 goes in, which also re-enables the simple plugins.

The PDF previewer has some extra margin at its base that does not exist on production.

Several of the PDFs result in error messages in the previewer (i.e., improperly formatted document); these also result in errors on production.


## Testing Instructions

 * `vagrant provision app`
 * Rebuild previewers (this step applies to all previewer extensions):
    - `vagrant ssh app`
    - `source /usr/lib/ckan/default/bin/activate`
    - `cd cd /usr/lib/ckan/default/src/ckan`
    - `paster views create -c /etc/ckan/default/production.ini`
 * View a dataset with PDF document(s)
 * Select to preview the PDF
 * PDF previewer should display within a tab

## Checklist

- [ ] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?

Closes azavea/urban-apps#150

