### PR TITLE
Add instructions for copying uploads between servers

### DIFF
--- a/UPGRADING_2.2_TO_2.8.md
+++ b/UPGRADING_2.2_TO_2.8.md
@@ -118,3 +118,18 @@ COMMIT;
   ckan search-index rebuild -r
   ckan views create -y
   ```
+
+### Copy uploaded images to the new server instance
+
+Many of the images used on the site (such as the Topic icons and the Organization logo images)
+are stored as uploads.  The files are on the server's file system and the Topic and Organization
+entities in the database store just the filename. To preserve the images when upgrading, copy
+them from the old server instance to the new.
+
+The path is `/var/lib/ckan/default/storage/uploads/`.
+
+If the new server is accessible from outside, copying them directly should work, i.e.:
+```
+scp -r ubuntu@opendataphilly.org:/var/lib/ckan/default/storage/uploads \
+       NEW_USERNAME@NEW_SERVER:/var/lib/ckan/default/storage/
+```


### PR DESCRIPTION
## Overview

Some of the images on the site, namely the topic icons:
![image](https://user-images.githubusercontent.com/6598836/45725819-9ab16c80-bb8a-11e8-82d9-ee27190aaee5.png)

and most of the Organization logos:
![image](https://user-images.githubusercontent.com/6598836/45725827-a3a23e00-bb8a-11e8-8e83-b1e038d8ff86.png)

are files that were uploaded on the configuration pages for those entities and are stored in an `uploads` directory on the server filesystem.  They're represented in the database by just the filename.  So when we upgrade, we'll need to keep those files to prevent all the images from breaking.

This adds instructions to the upgrade guide for doing so, by copying the directory to the new server instance.

### Notes

It would be nice to have the topic icons saved with the other assets (like the site logo) [in the ODP Theme extension](https://github.com/azavea/ckanext-odp_theme/tree/develop/ckanext/odp_theme/public/img).  But we'd still need to copy the uploads to preserve the organization logos, and transitioning to keeping the icons with the theme would require editing each of the Topic entities in the database to point to the different URL, so just copying `uploads` over seems fine.

## Testing Instructions

Use the first part of the SCP command to copy the uploads to a local directory that's visible inside your `app` VM, then copy them into place inside the VM.  Your development instance should now have all the images that the live site has (the remaining broken images are due to broken external links).

## Checklist

- [x] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?

Connects https://github.com/azavea/urban-apps/issues/147