### PR TITLE
Migrate 'related' to 'showcase'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ service apache2 start
 ```
 /usr/lib/ckan/default/bin/paster search-index rebuild --config=/etc/ckan/default/production.ini
 ```
+
+### Rebuild views
+```
+ckan views create -y
+```

--- a/UPGRADING_2.2_TO_2.8.md
+++ b/UPGRADING_2.2_TO_2.8.md
@@ -116,4 +116,5 @@ COMMIT;
   service apache2 restart
   service jetty restart
   ckan search-index rebuild -r
+  ckan views create -y
   ```

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -25,3 +25,9 @@ ckan_simple_plugins:
       - 'pdf_view'
     default_views:
       - 'pdf_view'
+  - name: 'ckanext-showcase'
+    repo: 'ckan/ckanext-showcase'
+    version: '87a7a6e1d3566edae615613f705b3b83bef75281'
+    plugins:
+      - 'showcase'
+    default_views: []

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -25,8 +25,3 @@ ckan_simple_plugins:
       - 'pdf_view'
     default_views:
       - 'pdf_view'
-  # - name: 'highlight-related-items'
-  #   repo: 'CityOfPhiladelphia/ckanext-highlight-related-items'
-  #   version: 'fefd941267d2c4f2551656b52af5b5fe601a7882'
-  #   plugins:
-  #     - 'highlight-related-items'

--- a/deployment/ansible/roles/ckan.app/defaults/main.yml
+++ b/deployment/ansible/roles/ckan.app/defaults/main.yml
@@ -26,8 +26,8 @@ ckan_simple_plugins:
     default_views:
       - 'pdf_view'
   - name: 'ckanext-showcase'
-    repo: 'ckan/ckanext-showcase'
-    version: '87a7a6e1d3566edae615613f705b3b83bef75281'
+    repo: 'azavea/ckanext-showcase'
+    version: 'master'
     plugins:
       - 'showcase'
     default_views: []


### PR DESCRIPTION
This is PR #81, except that that was originally created as a chained PR on the branch for PR #82 and I forgot to reset the branch and rebase #81 after merging #82.

So now this is rebased onto `develop`.  I took the opportunity to also
- Point the `ckanext-showcase` version at `master` rather than a commit hash on a branch of [our fork](https://github.com/azavea/ckanext-showcase)
- Add a line for rebuilding views to the list of commands needed to restart/reload

Resolves https://github.com/azavea/urban-apps/issues/155

