### PR TITLE
Persist Nginx config to block web crawlers

### DIFF
--- a/deployment/ansible/roles/ckan-odp-configuration/templates/nginx_ckan.j2
+++ b/deployment/ansible/roles/ckan-odp-configuration/templates/nginx_ckan.j2
@@ -1,6 +1,11 @@
 proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=cache:30m max_size=250m;
 proxy_temp_path /tmp/nginx_proxy 1 2;
 
+map $http_user_agent $limit_bots {
+    default 0;
+    ~*(semrush|mj12bot|ahrefs|webmeup) 1;
+}
+
 server {
     listen 80;
     return 301 {{ ckan_site_url }}$request_uri;
@@ -17,6 +22,9 @@ server {
     {% endif %}
     client_max_body_size 100M;
     location / {
+        if ($limit_bots = 1) {
+            return 403;
+        }
         proxy_pass http://127.0.0.1:8080/;
         proxy_set_header Host $host;
         proxy_cache cache;


### PR DESCRIPTION
## Overview

During the incident described in #92, we adjusted the Nginx configuration directly on the server to block aggressive web crawlers. Persist that config change in the codebase so that it will be replicated the next time the app gets provisioned.

### Notes

- The canonical way to block these bots would be to define this behavior in `/robots.txt`. I'm curious whether we should add `robots.txt` in this PR as well?

- While making this change, I did a quick audit of bot behavior in the logs to confirm that we want to block these bots. As a result, I removed one bot from the original list defined in #91, `qwant`, which is a crawler for a [legitimate search engine](https://www.qwant.com/) that only sent requests once per 30 seconds or so and stopped sending requests on 11/29.

- Blocking SemRushBot alone would have eliminated roughly half of the traffic between 11/25/18 and 12/3/18:

```
$ cat ckan_default.custom.log.1 | grep semrush | wc -l
  199198
$ cat ckan_default.custom.log.1 | wc -l
  425253
```


## Testing Instructions

 * Not really sure what the best way to test this PR is. Perhaps shell into the server and compare it to the live Nginx config at `/etc/nginx/sites-available/ckan`?

## Checklist

- [X] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)? (**N/A**)

Resolves #91

