### PR TITLE
Install PostgreSQL 11.x in development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,7 +80,7 @@ Vagrant.configure(2) do |config|
     app.vm.network "private_network", ip: "192.168.8.85"
     app.vm.hostname = "app"
 
-    app.vm.synced_folder "../ckanext-odp_theme", "/vagrant_ckanext-odp_theme", nfs: true
+    app.vm.synced_folder "../ckanext-odp_theme", "/vagrant_ckanext-odp_theme"
 
     app.vm.provision :ansible do |ansible|
       ansible.playbook = "deployment/ansible/app.yml"

--- a/deployment/ansible/group_vars/vagrant.example
+++ b/deployment/ansible/group_vars/vagrant.example
@@ -8,6 +8,8 @@ db_password: ckan_default
 datastore_user: datastore_default
 datastore_db: datastore_default
 db_host: database.service.opendataphilly.internal
+postgresql_version: "11"
+postgresql_package_version: "11*.pgdg14.04+1"
 postgresql_listen_addresses: "{{ db_host }}, localhost"
 postgresql_hba_mapping:
   - type: host


### PR DESCRIPTION
## Overview

- Install PostgreSQL 11.x in development
- Use VirtualBox synced folder type (`nfs` was preventing the app from provisioning on my workstation)

Resolves #101 

## Demo

<img width="1743" alt="image" src="https://user-images.githubusercontent.com/1774125/63806113-dc917980-c8e8-11e9-9632-9af49ea9915e.png">

## Testing Instructions
- Generate a dump of the production CKAN database:
```bash
pg_dump -U ckan_default -h database.service.opendataphilly.internal --format=custom -d ckan_default > ckan.dump
```
- Bring up the development environment, following steps 1-4 of [development installation](https://github.com/azavea/opendataphilly-ckan#development-installation)
- Clean the CKAN database, from the `app` VM:
```bash
sudo su
source /usr/lib/ckan/default/bin/activate
paster --plugin=ckan db clean -c /etc/ckan/default/production.ini
```
- Restore the CKAN database, from the `database` VM:
```bash
sudo -u postgres pg_restore --clean --if-exists -d ckan_default < ckan.dump
```
- Rebuild the search index, from the `app` VM:
```bash
paster --plugin=ckan search-index rebuild --config=/etc/ckan/default/production.ini
```
- Verify PostgreSQL 11 is installed:
```bash
$ sudo -u postgres psql -c "select version();"
                                                              version
-----------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 11.3 (Ubuntu 11.3-1.pgdg14.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4, 64-bit
(1 row)
```
- Verify http://localhost:8025 reflects https://opendataphilly.org
