### PR TITLE
Run certbot renewal every 1st and 15th day of the month

### DIFF
--- a/deployment/ansible/roles/ckan-odp-configuration/tasks/letsencrypt.yml
+++ b/deployment/ansible/roles/ckan-odp-configuration/tasks/letsencrypt.yml
@@ -4,9 +4,9 @@
   template: src=nginx_ckan_letsencrypt.j2
             dest=/etc/nginx/sites-available/ckan
             mode="0644"
-            
+
 - name: Restart Apache service
-  service: name=apache2 state=restarted            
+  service: name=apache2 state=restarted
 
 - name: Restart Nginx service
   service: name=nginx state=restarted
@@ -30,7 +30,7 @@
     name: "Renew Let's Encrypt Certificate"
     minute: 0
     hour: 23
-    day: 25
+    day: "1,15"
     job: "certbot-auto renew --quiet --no-self-upgrade && service nginx reload"
 
 - name: Copy Nginx Configuration


### PR DESCRIPTION
## Overview

Increases the frequency for the certbot renewal cron job from once per month to twice per month. Since the default time to expiry for a renewal is 30 days, this avoids an edge case where a certificate may expire before the job has a chance to successfully run on the same day.

### Notes

There are a few trailing whitespace fixes in this PR. You may want to disable viewing whitespace while reviewing the diff.

## Testing Instructions

This is going to be difficult to verify locally, since we don't set up certbot in Vagrant. The change is minor enough that we may want to deploy to production and then verify that the `crontab` interval is correctly set to run on `1,15`:

```#bash
$ sudo crontab -l
#Ansible: Renew Let's Encrypt Certificate
0 23 1,15 * * certbot-auto renew --quiet --no-self-upgrade && service nginx reload
```

## Checklist

- [x] Manual upgrade steps added to [UPGRADING_2.2_TO_2.8.md](UPGRADING_2.2_TO_2.8.md)?

Resolves #97 

